### PR TITLE
Add link to fluent/fluent-logger-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Fluent Logger Node.js
 
+This library has been unmaintained since 7 years ago.
+Please use https://github.com/fluent/fluent-logger-node instead of this library.
+
 **fluent-logger-node** is a structured event logger for Fluent.
 
 [![Build Status](https://secure.travis-ci.org/dakatsuka/fluent-logger-node.png)](http://travis-ci.org/dakatsuka/fluent-logger-node)


### PR DESCRIPTION
I'm a maintainer of https://github.com/fluent/fluent-logger-node.
Our user reported the issue https://github.com/fluent/fluent-logger-node/issues/140.
Please check comments from the user.

Please merge this PR if you don't use this library anymore.
And please unpublish `fluent-logger-node` package published on https://www.npmjs.com/package/fluent-logger-node because it will cause confusion to users.